### PR TITLE
Update example request API URLs to reactor.adobe.io

### DIFF
--- a/_plugins/scenario_tag.rb
+++ b/_plugins/scenario_tag.rb
@@ -12,7 +12,7 @@ class Jekyll::ScenarioTag < Liquid::Tag
 
   def build_curl_request
     <<EOF
-curl https://reactor-integration.adobe.io#{@endpoint['path']} \\
+curl https://reactor.adobe.io#{@endpoint['path']} \\
   -H "Accept: application/vnd.api+json;revision=1" \\
   -H "Content-Type: application/vnd.api+json" \\
   -H "Authorization: Bearer [TOKEN]" \\

--- a/api/reference/1.0/extension_packages/create.md
+++ b/api/reference/1.0/extension_packages/create.md
@@ -100,7 +100,7 @@ When an `ExtensionPackage` is created, `availability` is set to `development`. A
 
   <h1 id="example-request">Example Request<a class="anchorjs-link " href="#example-request" aria-label="Anchor link for: example request" data-anchorjs-icon="" style="font-family: anchorjs-icons; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: normal; line-height: 1; padding-left: 0.375em;"></a></h1>
 <div class="highlight">
-  <pre><code>curl https://reactor-integration.adobe.io/extension_packages <span class="se">\</span>
+  <pre><code>curl https://reactor.adobe.io/extension_packages <span class="se">\</span>
   -H <span class="s2">"Accept: application/vnd.api+json;revision=1"</span> <span class="se">\</span>
   -H <span class="s2">"Content-Type: multipart/form-data"</span> <span class="se">\</span>
   -H <span class="s2">"Authorization: Bearer [TOKEN]"</span> <span class="se">\</span>
@@ -142,7 +142,7 @@ When an `ExtensionPackage` is created, `availability` is set to `development`. A
       </span><span class="nt">"view_base_path"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="w">
     </span><span class="p">},</span><span class="w">
     </span><span class="nt">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-      </span><span class="nt">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"https://reactor-integration.adobe.io/extension_packages/EP10bb503178694d73bc0cd84387b82172"</span><span class="w">
+      </span><span class="nt">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"https://reactor.adobe.io/extension_packages/EP10bb503178694d73bc0cd84387b82172"</span><span class="w">
     </span><span class="p">}</span><span class="w">
   </span><span class="p">}</span><span class="w">
 </span><span class="p">}</span></code></pre>

--- a/api/reference/1.0/extension_packages/release_private.md
+++ b/api/reference/1.0/extension_packages/release_private.md
@@ -22,7 +22,7 @@ A Private release is achieved by supplying an `action` with a value of `release_
 
   <h1 id="example-request">Example Request<a class="anchorjs-link " href="#example-request" aria-label="Anchor link for: example request" data-anchorjs-icon="" style="font-family: anchorjs-icons; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: normal; line-height: 1; padding-left: 0.375em;"></a></h1>
 <div class="highlight">
-  <pre><code>curl https://reactor-integration.adobe.io/extension_packages/:id <span class="se">\</span>
+  <pre><code>curl https://reactor.adobe.io/extension_packages/:id <span class="se">\</span>
   -H <span class="s2">"Accept: application/vnd.api+json;revision=1"</span> <span class="se">\</span>
   -H <span class="s2">"Content-Type: application/vnd.api+json"</span> <span class="se">\</span>
   -H <span class="s2">"Authorization: Bearer [TOKEN]"</span> <span class="se">\</span>

--- a/api/reference/1.0/extension_packages/update.md
+++ b/api/reference/1.0/extension_packages/update.md
@@ -68,7 +68,7 @@ This endpoint expects multipart requests.
 
   <h1 id="example-request">Example Request<a class="anchorjs-link " href="#example-request" aria-label="Anchor link for: example request" data-anchorjs-icon="" style="font-family: anchorjs-icons; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: normal; line-height: 1; padding-left: 0.375em;"></a></h1>
 <div class="highlight">
-  <pre><code>curl https://reactor-integration.adobe.io/extension_packages/:id <span class="se">\</span>
+  <pre><code>curl https://reactor.adobe.io/extension_packages/:id <span class="se">\</span>
   -H <span class="s2">"Accept: application/vnd.api+json;revision=1"</span> <span class="se">\</span>
   -H <span class="s2">"Content-Type: multipart/form-data"</span> <span class="se">\</span>
   -H <span class="s2">"Authorization: Bearer [TOKEN]"</span> <span class="se">\</span>
@@ -111,7 +111,7 @@ This endpoint expects multipart requests.
       </span><span class="nt">"view_base_path"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="w">
     </span><span class="p">},</span><span class="w">
     </span><span class="nt">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-      </span><span class="nt">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"https://reactor-integration.adobe.io/extension_packages/EP0393ce01ac3540acb78f103d8e58a5a0"</span><span class="w">
+      </span><span class="nt">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"https://reactor.adobe.io/extension_packages/EP0393ce01ac3540acb78f103d8e58a5a0"</span><span class="w">
     </span><span class="p">}</span><span class="w">
   </span><span class="p">}</span><span class="w">
 </span><span class="p">}</span></code></pre>


### PR DESCRIPTION
#### Purpose

Move API example requests to use `reactor.adobe.io` instead of `reactor-integration.adobe.io`.