### PR TITLE
Release notes and breaking changes

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -3,36 +3,20 @@ title: Overview
 layout: documentation
 ---
 
-{% alert warning, ATTENTION %}
+{% alert error, BREAKING CHANGES %}
 
-Domains beginning with `mc-api-activation-` have been deprecated and will be removed soon.
+**The Reactor API is preparing for a 1.0 release on May 1, 2019.**
 
-**Please migrate API requests to the new domains as outlined below.**
+Starting with this 1.0 release, the Reactor API will maintain backwards compatibility so that you can build on top of it in production settings without worrying about breaking changes.
 
-`mc-api-activation-reactor[-environment].adobe.io` -> `reactor[-environment].adobe.io`
+However, there are a few breaking changes that we need to make in preparation for that release.  See [Breaking Changes](/api/release_notes/breaking-changes) for details on what changes are being made and what you'll need to do to accommodate those changes before May 1.
 
-For example:
-
-- `mc-api-activation-reactor.adobe.io` -> `reactor.adobe.io`
-- `mc-api-activation-reactor-integration.adobe.io` -> `reactor-integration.adobe.io`
 {% endalert %}
 
-<br>
- 
 # API First
 
 Launch, by Adobe is an entirely API-first application.  All system functionality is accessible through the API.  The UI at [launch.adobe.com](https://launch.adobe.com) is simply a friendly way to interact with them.
 
-The Launch API - known as Reactor - uses the JSON API specification.  We expect inputs to be compliant with this specification and all outputs are also compliant.  You can read more at [jsonapi.org](http://jsonapi.org/).
+This API - known as the Reactor API - uses the JSON API specification.  We expect inputs to be compliant with this specification and all outputs are also compliant.  You can read more at [jsonapi.org](http://jsonapi.org/).
 
-# Alpha State
-
-{% alert error, WARNING %}
-**These APIs are currently in an _'alpha'_ state and are likely to change over time. Please do not use them in a production setting!**
-{% endalert %}
-
-The Launch UI has been generally available to all Experience Cloud customers since March of 2018.  The development team is moving quickly to add additional features.  This development requires us to add new APIs and in some cases change the behavior of existing APIs.
-
-It's not a problem for the UI because we can make sure that changes are made in both places, but it is a problem for anyone using the APIs directly.
-
-At the moment, the Reactor APIs are in an Alpha State.  You are welcome to use them, but you should not rely on them for anything running in a production state.  Until we offer an official v1.0 release of the APIs and commit to backwards compatibility, you should operate under the assumption that we will change them at any time without warning.
+The full API specification is available under Reference > 1.0 in the navigation.

--- a/api/release_notes/2019-release-notes.md
+++ b/api/release_notes/2019-release-notes.md
@@ -1,0 +1,9 @@
+---
+title: 2019 Release Notes
+---
+
+# 2019 Reactor Release Notes
+
+## 2019-03-
+
+Release notes are incoming with our next release.

--- a/api/release_notes/breaking-changes.md
+++ b/api/release_notes/breaking-changes.md
@@ -36,15 +36,58 @@ This means that the mechanism for creating Rule Components and the way that they
 
 **POST**
 
-[TODO] Currently in order to create a rule,  you ...
+Currently, in order to create a rule component, you do a POST to `/rules/:rule_id/rule_components` with the following payload body:
+```
+{
+  "data": {
+    "attributes": {
+      "delegate_descriptor_id": "kessel-test::events::click",
+      "name": "My Example Click Event",
+      "settings": "{\"elementSelector\":\".accordion\",\"bubbleFireIfChildFired\":true}"
+    },
+    "relationships": {
+      "extension": {
+        "data": {
+          "id": "EX9d00daf64549414caf28ed48e62da98c",
+          "type": "extensions"
+        }
+      }
+    },
+    "type": "rule_components"
+  }
+}
+```
 
-[TODO] The new way to create a rule is to ...
-
-**PATCH**
-
-[TODO] Currently in order to update a rule, you ...
-
-[TODO] The new way to update a rule is to ...
+The new way to create a rule component is doing a POST to `properties/:property_id/rule_components` with a slightly different payload body.
+The change to the payload body consists in adding the rules relationship, which, at this point, can only have one rule:
+```
+{
+  "data": {
+    "attributes": {
+      "delegate_descriptor_id": "kessel-test::events::click",
+      "name": "My Example Click Event",
+      "settings": "{\"elementSelector\":\".accordion\",\"bubbleFireIfChildFired\":true}"
+    },
+    "relationships": {
+      "extension": {
+        "data": {
+          "id": "EX9d00daf64549414caf28ed48e62da98c",
+          "type": "extensions"
+        }
+      },
+      "rules": {
+        "data": [
+          {
+            "id": "RL76c41cada90344989e25d091fa677f29",
+            "type": "rules
+          }
+        ]
+      }
+    },
+    "type": "rule_components"
+  }
+}
+```
 
 {% endalert %}
 

--- a/api/release_notes/breaking-changes.md
+++ b/api/release_notes/breaking-changes.md
@@ -113,7 +113,7 @@ These endpoints are paginated and filterable like all other list endpoints.
 
 **GET Rule and include Rule Components**
 
-Currenly if you want to retrieve the Rule Components in a Rule, you can do it in two ways:
+Currently if you want to retrieve the Rule Components in a Rule, you can do it in two ways:
 `rules/:id/rule_components`
 `rules/:id?include=rule_components`
 
@@ -176,18 +176,45 @@ So if you're using `LIKE` you need to change it to `CONTAINS` to keep the same b
 
 From the beginning, whenever we've Adapters have come up in a conversation, we immediately have to describe what it is, because the meaning is not obvious from the name.  We've put this off long enough, and we're changing the name.
 
-`Adapter` is changing to `Host`.  Along with this change, there is actually a `host` attribute on the `Adapter`, and having a `Host.host` attribute is just confusing, so this attribute is changing to be `Host.url`.
+`Adapter` is changing to `Host`.  Along with this change, there is actually a `host` attribute on the `Adapter`, and having a `Host.host` attribute is just confusing, so this attribute is changing to be `Host.server`.
 
 #### POST
 
-[TODO]
+To create a `Host`, you need to do a `POST /properties/:property_id/hosts` with the a payload body similar to:
+```
+{
+  "data": {
+    "attributes": {
+      "name": "Example SFTP Host",
+      "type_of": "sftp",
+      "username": "John Doe",
+      "encrypted_private_key": "-----BEGIN PGP MESSAGE-----\n\nhQIMAwB8kNQ7jtk8AQ/+IPE+jteweLyNgdkzkBWN4c+wpRfTP9ionSywdWzZsRZ2\ngpIHLidqCgM+iRw0CgbAKhdAmA1wVyWP4HCa0eJuNCVwj+NqJlWW8qWxCWeZi2KC\nhqsoaB5+xIbS3Jwt8S4Na+DgvyjSj88sALvG9Y/xqNexRvcuvv0KKFoVYPOeW/w9\n+6x+vUmZFrTWMaNtKH6X9kifo5l+05d3XngPLfml4cKzWmO1f3FEvTX0O4nJurQ7\nNc27dt2XAO5Y8bqCClQ6AHOFVrkKnTifHF79A3AhCB5E9wMY4FJ/EReZ6Uk0ixOn\n76XeGbkl1jidajM5G/gylwEwOXN8CVy5DQyvxGulhsaaqtri7GZxQC5HUTETIHwO\nxThAttH22uaBjhMmYiCvPzSL4Z9UNFZeGPfb17k5E1kauprR2ItUJX86+Cid/FnR\nW7QN/8J4Jnf6Ggp90VujV0uIvdyLYq3T0xe9WZmONJaQ5bDYDv5ZfkcapOvXw4zr\nxrL1vrpZ5Qfu8oLQ19JOT2o7e3p8Kh7lDPIL7RH2bYesinLJ7wdopmkpj4/4gpHK\njzlWalZd75PEsttsUJ+ODVSOXG7iVhx9EvkZagUo0oeZ3oY1Jy5oik/gvVp28wDO\n8T1uYK/jeCSiuslxCYxth8a+5Wgiy8Jw1vHCRudsNgU1x2zYuOJetJS14Z/CTETS\nTgGPh0J6fQEvzZTM6AEJpRs+cVZV1hnTspyo2S5wv/SdrbqMkVHhs8rlq/0PWpSB\nLhLNlh8kLPR0KOG0V79GEO20At0HL/yGny/GKrTyAw==\n=oRpa\n-----END PGP MESSAGE-----\n",
+      "server": "//example.com",
+      "path": "assets",
+      "port": 22
+    },
+    "type": "hosts"
+  }
+}
+```
 
 #### PATCH
 
-[TODO]
+To update a `Host`, you need to do a `PATCH /properties/:property_id/hosts` with the a payload body similar to:
+```
+{
+  "data": {
+    "attributes": {
+      "name": "My new SFTP Host"
+    },
+    "id": "HT294b93994b7c462285602283a6437e43",
+    "type": "hosts"
+  }
+}
+```
 
 #### GET
 
-[TODO]
+To fetch a `Host`, you need to do a `GET /hosts/:id`
 
 {% endalert %}

--- a/api/release_notes/breaking-changes.md
+++ b/api/release_notes/breaking-changes.md
@@ -10,9 +10,9 @@ The intent is to give all API users the notice of these changes and the knowledg
 
 This document contains detailed descriptions of each of the breaking changes.
 
-## Changes With A Cutover Period
+## Changes With A Deprecation Period
 
-There are a few changes where the new API endpoints/payloads will exist in the Launch production environment side-by-side with the old.  These are in production already or will be very soon (keep an eye on the [release notes](/api/release-notes/2019-release-notes)) and you can make the changes now.
+There are a few changes where the new API endpoints/payloads will exist in the Launch production environment side-by-side with the old.  These are in production already or will be very soon (keep an eye on the [release notes](/api/release-notes/2019-release-notes)).  You should make these changes as soon as possible and prior to May 1 when the old method will go away.
 
 {% alert warning, Change #1: New Domains for the API %}
 
@@ -80,11 +80,9 @@ We are changing the `/library` endpoint to be consistent with the way you retrie
 
 ## Changes That Require a Hard Cutover
 
-For a few of these changes, it is not easy for us to deploy the new method side-by-side with the old, so you'll have to make a hard cutover.
+For a few of these changes, it is not feasible for us to deploy the new method side-by-side with the old, so you'll have to make a hard cutover.
 
-For these changes, we are providing the Integration environment where the new changes will be deployed so that you can test your changes before they go live.  You'll need to test these changes in the Integration environment prior to May 1.
-
-Then on May 1, these changes will go live in Production and you'll need to update your API usage after that before they will function again in Production.
+These changes will be released to Production on May 1 and you'll need to update your API usage after that before they will function again.
 
 {% alert error, Change #5: LIKE changes to CONTAINS %}
 

--- a/api/release_notes/breaking-changes.md
+++ b/api/release_notes/breaking-changes.md
@@ -28,15 +28,76 @@ For 99% of you, the only domain you'll need to worry about is the production dom
 
 {% endalert %}
 
-{% alert warning, Change #2: Rule Components Move to Property %}
+{% alert warning, Change 2: Library Resources Move to Specific Endpoints %}
+
+Right now, when you want to see what resources are contained in a Library, you hit the `/library/:library_id/resources` endpoint.  When you want to see what resources are in a Build, you ask for the different resource types separately:
+
+```
+/build/:build_id/extensions
+/build/:build_id/dataElements
+/build/:build_id/rules
+```
+
+We are changing the `/library` endpoint to be consistent with the way you retrieve resources for builds. From now on you'll use:
+
+```
+/library/:library_id/extensions
+/library/:library_id/data_elements
+/library/:library_id/rules
+```
+
+{% endalert %}
+
+{% alert warning, Change #3: No Unbounded Includes %}
+
+There are two places in the Reactor API where you can make a request for a resource and have it return an unbounded list of additional resources that come along with it.  You can do this with Libraries (to get the included resources) and you can do it with Rules (to get the included Rule Components)
+
+From now on, you'll need to hit an endpoint underneath the "parent" resource in order to retrieve the included resources.  These endpoints are paginated and filterable like all other list endpoints.
+
+### GET Library and include Resources
+
+Currently if you want to retrieve the resources in a Library, you can do it two ways:
+
+```
+/libraries/:library_id?include=resources
+/libraries/:library_id/resources
+```
+
+The first method is going away because we will no longer allow the unbounded include.  The second method is no longer available because of the changes described above in Change #2, so the way to retrieve the resources within a Library is to call each relationship endpoint explicitly.
+
+```
+libraries/:library_id/relationships/data_elements
+libraries/:library_id/relationships/extensions
+libraries/:library_id/relationships/rules
+```
+
+### GET Rule and include Rule Components
+
+Currently if you want to retrieve the Rule Components in a Rule, you can do it in two ways:
+
+```
+rules/:rule_id/rule_components
+rules/:rule_id?include=rule_components
+```
+
+This second method is going away, so only way to retrieve the Rule Components that are used by a Rule is:
+
+```
+rules/:rule_id/rule_components
+```
+
+{% endalert %}
+
+{% alert warning, Change #4: Rule Components Move to Property %}
 
 Each Rule Component exists as a child of a Rule.  This makes it impossible to reuse the same components across rules.  In order to enable us to add this capability in the future, Rule Components need to move out from under a Rule and live at the Property level.
 
 This means that the mechanism for creating Rule Components and the way that they relate to Rules needs to change.
 
-**POST**
+### POST
 
 Currently, in order to create a rule component, you do a POST to `/rules/:rule_id/rule_components` with the following payload body:
+
 ```
 {
   "data": {
@@ -60,6 +121,7 @@ Currently, in order to create a rule component, you do a POST to `/rules/:rule_i
 
 The new way to create a rule component is doing a POST to `properties/:property_id/rule_components` with a slightly different payload body.
 The change to the payload body consists in adding the rules relationship, which, at this point, can only have one rule:
+
 ```
 {
   "data": {
@@ -91,69 +153,6 @@ The change to the payload body consists in adding the rules relationship, which,
 
 {% endalert %}
 
-{% alert warning, Change #3: No Unbounded Includes %}
-
-There are a few places in the Reactor API where you can make a request for a resource and have it return an unbounded list of additional resources that come along with it.
-
-One example is asking for a Library and all of its resources (Data Elements, Rules, and Extension).  This is nice as a shortcut, but it doesn't scale well.
-
-From now one, you'll need to hit a paginated endpoint underneath the "parent" resource in order to retrieve the included resources.
-
-**GET Library and include Resources**
-
-Currently if you want to retrieve the resources in a Library, you can do it two ways:
-`/libraries/\:id?include=resources`
-`/libraries/:id/resources`
-
-The new way to retrieve the resources within a Library is to call each relationship endpoint explicitly.
-`libraries/\:id/relationships/data_elements`
-`libraries/\:id/relationships/extensions`
-`libraries/\:id/relationships/rules`
-These endpoints are paginated and filterable like all other list endpoints.
-
-**GET Rule and include Rule Components**
-
-Currently if you want to retrieve the Rule Components in a Rule, you can do it in two ways:
-`rules/:id/rule_components`
-`rules/:id?include=rule_components`
-
-The new way to retrieve the Rule Components that are used by a Rule is to ...
-`rules/:id/rule_components`
-
-The new way to associate Rule Components to a rule is:
-
-To replace the rule's existing rule_components with a new set of rule_components:
-`PATCH rules/:id/relationships/rule_components` with a body:
-```
-{
-  "data": [
-    { "type": "rule_components", "id": "2" },
-    { "type": "rule_components", "id": "3" }
-  ]
-}
-```
-
-To add a rule_component to the rule's existing rule_components:
-`POST rules/:id/relationships/rule_components` with a body:
-```
-{
-  "data": [
-    { "type": "rule_components", "id": "4" },
-    { "type": "rule_components", "id": "5" }
-  ]
-}
-```
-
-{% endalert %}
-
-{% alert warning, Change 4: Library Resources Move to Specific Endpoints %}
-
-Right now, when you want to see what resources are contained in a Library, you hit the `/library/:id/resources` endpoint.  When you want to see what resources are in a Build, you ask for the different resource types separately (`/build/:id/extensions`, `/build/:id/dataElements`, and `/build/:id/rules`).
-
-We are changing the `/library` endpoint to be consistent with the way you retrieve resources for builds. So you'll have `/library/:id/extensions`, `/library/:id/dataElements`, and `/library/:id/rules`
-
-{% endalert %}
-
 ## Changes That Require a Hard Cutover
 
 For a few of these changes, it is not feasible for us to deploy the new method side-by-side with the old, so you'll have to make a hard cutover.
@@ -164,11 +163,7 @@ These changes will be released to Production on May 1 and you'll need to update 
 
 Currently there are a few places where you filter an endpoint to trim down the result set that you'll get.  You can use the `LIKE` keyword in those filters, but it actually behaves like a "contains" filter.
 
-We're changing that specific keyword to `CONTAINS` so it matches the "contains" behavior.  
-
-We're also keeping the `LIKE` keyword, but changing the behavior to actually match a SQL `LIKE`.
-
-So if you're using `LIKE` you need to change it to `CONTAINS` to keep the same behavior.  And if you actually wanted a `LIKE` filter, now you have one.
+We're changing this keyword to `CONTAINS` so it matches the behavior.  If you're using the `LIKE` modifier, you'll need to update it to `CONTAINS`.
 
 {% endalert %}
 
@@ -178,7 +173,7 @@ From the beginning, whenever we've Adapters have come up in a conversation, we i
 
 `Adapter` is changing to `Host`.  Along with this change, there is actually a `host` attribute on the `Adapter`, and having a `Host.host` attribute is just confusing, so this attribute is changing to be `Host.server`.
 
-#### POST
+### POST
 
 To create a `Host`, you need to do a `POST /properties/:property_id/hosts` with the a payload body similar to:
 ```
@@ -198,7 +193,7 @@ To create a `Host`, you need to do a `POST /properties/:property_id/hosts` with 
 }
 ```
 
-#### PATCH
+### PATCH
 
 To update a `Host`, you need to do a `PATCH /properties/:property_id/hosts` with the a payload body similar to:
 ```
@@ -215,6 +210,6 @@ To update a `Host`, you need to do a `PATCH /properties/:property_id/hosts` with
 
 #### GET
 
-To fetch a `Host`, you need to do a `GET /hosts/:id`
+To fetch a `Host`, you need to do a `GET /hosts/:host_id`
 
 {% endalert %}

--- a/api/release_notes/breaking-changes.md
+++ b/api/release_notes/breaking-changes.md
@@ -1,0 +1,119 @@
+---
+title: Breaking Changes
+---
+
+# Breaking Changes for Reactor API 1.0
+
+The Reactor API that powers Launch is preparing for it's initial 1.0 release on May 1.  This release will come along with a commitment to backward compatibility.  But we are not there yet, and there are a few breaking changes that we need to make in preparation for that release.
+
+The intent is to give all API users the notice of these changes and the knowledge/tools they'll need in order to upgrade their API usage to accomodate these changes prior to their release on May 1.
+
+This document contains detailed descriptions of each of the breaking changes.
+
+## Changes With A Cutover Period
+
+There are a few changes where the new API endpoints/payloads will exist in the Launch production environment side-by-side with the old.  These are in production already or will be very soon (keep an eye on the [release notes](/api/release-notes/2019-release-notes)) and you can make the changes now.
+
+{% alert warning, Change #1: New Domains for the API %}
+
+Currently, when you make a request to the Reactor API, the domain is structured as follows:
+
+`mc-api-activation-reactor[-environment].adobe.io`
+
+These are now much simpler and the new domains are:
+
+`reactor[-environment].adobe.io`
+
+For 99% of you, the only domain you'll need to worry about is the production domain which is simply `reactor.adobe.io`.
+
+{% endalert %}
+
+{% alert warning, Change #2: Rule Components Move to Property %}
+
+Each Rule Component exists as a child of a Rule.  This makes it impossible to reuse the same components across rules.  In order to enable us to add this capability in the future, Rule Components need to move out from under a Rule and live at the Property level.
+
+This means that the mechanism for creating Rule Components and the way that they relate to Rules needs to change.
+
+**POST**
+
+[TODO] Currently in order to create a rule,  you ...
+
+[TODO] The new way to create a rule is to ...
+
+**PATCH**
+
+[TODO] Currently in order to update a rule, you ...
+
+[TODO] The new way to update a rule is to ...
+
+{% endalert %}
+
+{% alert warning, Change #3: No Unbounded Includes %}
+
+There are a few places in the Reactor API where you can make a request for a resource and have it return an unbounded list of additional resources that come along with it.
+
+One example is asking for a Library and all of its resources (Data Elements, Rules, and Extension).  This is nice as a shortcut, but it doesn't scale well.
+
+From now one, you'll need to hit a paginated endpoint underneath the "parent" resource in order to retrieve the included resources.
+
+**GET Library and include Resources**
+
+[TODO] Currently if you want to retrieve the resources in a Library, you...
+
+[TODO] The new way to retrieve the resources within a Library is to ...
+
+**GET Rule and include Rule Components**
+
+[TODO] Currenly if you want to retrieve the Rule Components in a Rule, you...
+
+[TODO] The new way to retrieve the Rule Components that are used by a Rule is to ...
+
+{% endalert %}
+
+{% alert warning, Change 4: Library Resources Move to Specific Endpoints %}
+
+Right now, when you want to see what resources are contained in a Library, you hit the `/library/:id/resources` endpoint.  When you want to see what resources are in a Build, you ask for the different resource types separately (`/build/:id/extensions`, `/build/:id/dataElements`, and `/build/:id/rules`).
+
+We are changing the `/library` endpoint to be consistent with the way you retrieve resources for builds. So you'll have `/library/:id/extensions`, `/library/:id/dataElements`, and `/library/:id/rules`
+
+{% endalert %}
+
+## Changes That Require a Hard Cutover
+
+For a few of these changes, it is not easy for us to deploy the new method side-by-side with the old, so you'll have to make a hard cutover.
+
+For these changes, we are providing the Integration environment where the new changes will be deployed so that you can test your changes before they go live.  You'll need to test these changes in the Integration environment prior to May 1.
+
+Then on May 1, these changes will go live in Production and you'll need to update your API usage after that before they will function again in Production.
+
+{% alert error, Change #5: LIKE changes to CONTAINS %}
+
+Currently there are a few places where you filter an endpoint to trim down the result set that you'll get.  You can use the `LIKE` keyword in those filters, but it actually behaves like a "contains" filter.
+
+We're changing that specific keyword to `CONTAINS` so it matches the "contains" behavior.  
+
+We're also keeping the `LIKE` keyword, but changing the behavior to actually match a SQL `LIKE`.
+
+So if you're using `LIKE` you need to change it to `CONTAINS` to keep the same behavior.  And if you actually wanted a `LIKE` filter, now you have one.
+
+{% endalert %}
+
+{% alert error, Change #6: Adapter changes to Host %}
+
+From the beginning, whenever we've Adapters have come up in a conversation, we immediately have to describe what it is, because the meaning is not obvious from the name.  We've put this off long enough, and we're changing the name.
+
+`Adapter` is changing to `Host`.  Along with this change, there is actually a `host` attribute on the `Adapter`, and having a `Host.host` attribute is just confusing, so this attribute is changing to be `Host.url`.
+
+#### POST
+
+[TODO]
+
+#### PATCH
+
+[TODO]
+
+#### GET
+
+[TODO]
+
+{% endalert %}

--- a/api/release_notes/breaking-changes.md
+++ b/api/release_notes/breaking-changes.md
@@ -84,7 +84,7 @@ For a few of these changes, it is not feasible for us to deploy the new method s
 
 These changes will be released to Production on May 1 and you'll need to update your API usage after that before they will function again.
 
-{% alert error, Change #5: LIKE changes to CONTAINS %}
+{% alert error, Change #5: LIKE Changes to CONTAINS %}
 
 Currently there are a few places where you filter an endpoint to trim down the result set that you'll get.  You can use the `LIKE` keyword in those filters, but it actually behaves like a "contains" filter.
 
@@ -96,7 +96,7 @@ So if you're using `LIKE` you need to change it to `CONTAINS` to keep the same b
 
 {% endalert %}
 
-{% alert error, Change #6: Adapter changes to Host %}
+{% alert error, Change #6: Adapter Changes to Host %}
 
 From the beginning, whenever we've Adapters have come up in a conversation, we immediately have to describe what it is, because the meaning is not obvious from the name.  We've put this off long enough, and we're changing the name.
 

--- a/api/release_notes/breaking-changes.md
+++ b/api/release_notes/breaking-changes.md
@@ -58,15 +58,48 @@ From now one, you'll need to hit a paginated endpoint underneath the "parent" re
 
 **GET Library and include Resources**
 
-[TODO] Currently if you want to retrieve the resources in a Library, you...
+Currently if you want to retrieve the resources in a Library, you can do it two ways:
+`/libraries/\:id?include=resources`
+`/libraries/:id/resources`
 
-[TODO] The new way to retrieve the resources within a Library is to ...
+The new way to retrieve the resources within a Library is to call each relationship endpoint explicitly.
+`libraries/\:id/relationships/data_elements`
+`libraries/\:id/relationships/extensions`
+`libraries/\:id/relationships/rules`
+These endpoints are paginated and filterable like all other list endpoints.
 
 **GET Rule and include Rule Components**
 
-[TODO] Currenly if you want to retrieve the Rule Components in a Rule, you...
+Currenly if you want to retrieve the Rule Components in a Rule, you can do it in two ways:
+`rules/:id/rule_components`
+`rules/:id?include=rule_components`
 
-[TODO] The new way to retrieve the Rule Components that are used by a Rule is to ...
+The new way to retrieve the Rule Components that are used by a Rule is to ...
+`rules/:id/rule_components`
+
+The new way to associate Rule Components to a rule is:
+
+To replace the rule's existing rule_components with a new set of rule_components:
+`PATCH rules/:id/relationships/rule_components` with a body:
+```
+{
+  "data": [
+    { "type": "rule_components", "id": "2" },
+    { "type": "rule_components", "id": "3" }
+  ]
+}
+```
+
+To add a rule_component to the rule's existing rule_components:
+`POST rules/:id/relationships/rule_components` with a body:
+```
+{
+  "data": [
+    { "type": "rule_components", "id": "4" },
+    { "type": "rule_components", "id": "5" }
+  ]
+}
+```
 
 {% endalert %}
 


### PR DESCRIPTION
#### Purpose
Make a place for release notes and breaking changes.

#### Changes
- New section in /api for Release Notes
- Changed the {alert} on /api/index.md to point to /api/release-notes/breaking-changes.md for details on all the fun
- Added /api/release-notes/2019-release-notes.md with placeholder info.

#### Caveats
Nobody should merge or release this until someone from engineering has gone into /api/release-notes/breaking-changes.md and filled in all the [TODO] spots

#### Additional helpful information


