### PR TITLE
Update breaking change release date

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -5,7 +5,7 @@ layout: documentation
 
 {% alert error, BREAKING CHANGES %}
 
-**The Reactor API is preparing for a 1.0 release on May 1, 2019.**
+**The Reactor API is preparing for a 1.0 release on May 8, 2019.**
 
 Starting with this 1.0 release, the Reactor API will maintain backwards compatibility so that you can build on top of it in production settings without worrying about breaking changes.
 

--- a/api/reference/1.0/audit_events/index.md
+++ b/api/reference/1.0/audit_events/index.md
@@ -8,13 +8,20 @@ An `AuditEvent` is a record of a specific change to another resource in Launch, 
 
 Audit events are structured in the form of: `[RESOURCE_TYPE.EVENT]`. For example: `build.created`.
 
-Audit events are generated for the following resources:
-1. Properties
-1. Extensions
-1. Data Elements
-1. Rules
-1. Rule Components
-1. Libraries
-1. Builds
-1. Environments
-1. Adapters
+You can replace `RESOURCE_TYPE` with any of the following:
+
+1. `property`
+1. `extension`
+1. `data_element`
+1. `rule`
+1. `rule_component`
+1. `library`
+1. `build`
+1. `environment`
+1. `adapter`
+
+You can replace `EVENT` with any of the following:
+
+1. `created`
+1. `updated`
+1. `deleted`


### PR DESCRIPTION
#### Purpose
Update breaking change release date

#### Changes
Update breaking change release date to May 8
Also added some clarity to the audit_events docs based on Slack feedback I happened to get while I was changing the release date.

#### Caveats


#### Additional helpful information


