### PR TITLE
Improve page load times with slim font kit

### DIFF
--- a/css/docs.css
+++ b/css/docs.css
@@ -486,7 +486,7 @@ pre.html {
 }
 
 #main-nav a {
-  padding-bottom: 9px;
+  padding-bottom: 11px;
   text-decoration: none;
   margin-right: 20px;
 }

--- a/js/vendor/typekit.js
+++ b/js/vendor/typekit.js
@@ -4,12 +4,7 @@
   "use strict"
 
   var config = {
-    /* REPEAT AFTER ME:
-     I WILL NOT REUSE THE TYPEKIT ID FOR SPECTRUM-CSS DOCS IN MY PRODUCT
-     I WILL NOT REUSE THE TYPEKIT ID FOR SPECTRUM-CSS DOCS IN MY PRODUCT
-     I WILL NOT REUSE THE TYPEKIT ID FOR SPECTRUM-CSS DOCS IN MY PRODUCT
-     See https://wiki.corp.adobe.com/display/devrel/Using+Typekit+at+Adobe to get set up right. */
-    kitId: 'pbi5ojv',
+    kitId: 'wwo7pvd',
     scriptTimeout: 3000
   };
 


### PR DESCRIPTION
#### Purpose

Improve page load times by using a much smaller font kit.

#### Caveats

This font kit only contains `Source Sans Pro`. which is a fallback font when `adobe-clean` is unavailable. There's a process to get `adobe-clean` added to the kit which we can continue to pursue.

#### Additional helpful information

An example of how it looks using the `Source Sans Pro` fonts.

<img width="1765" alt="Screen Shot 2019-05-07 at 12 49 50 PM" src="https://user-images.githubusercontent.com/40956/57325154-a8d6dd80-70c6-11e9-8574-99c97ffb0544.png">
