### PR TITLE
Increase code area contrast in alerts

### DIFF
--- a/css/docs.css
+++ b/css/docs.css
@@ -715,3 +715,8 @@ blockquote.last {
 .docutils code {
   padding: 2px 5px 2px 5px;
 }
+
+.spectrum.spectrum--dark .spectrum-Alert pre,
+.spectrum.spectrum--dark .spectrum-Alert code {
+  background-color: rgb(50, 50, 50);
+}


### PR DESCRIPTION
#### Purpose

Increase code area contrast in alerts in dark mode.


#### Additional helpful information

Rendered example:

<img width="1869" alt="Screen Shot 2019-05-07 at 2 01 17 PM" src="https://user-images.githubusercontent.com/40956/57329644-75e61700-70d1-11e9-9c65-95af4c725c07.png">
