### PR TITLE
Alpha no more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /srv/docs
 
 ADD . /srv/docs
 
-RUN bundle install && \
+RUN bundle install --jobs 4 && \
     JEKYLL_ENV=production bundle exec jekyll build && \
     tar -czf /tmp/docs.tar.gz -C _site \
       --exclude=*.un~ \

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,7 +13,6 @@
     </a>
     <a href="/api" class="spectrum-Body2 guide-Header-link{% if url_parts[1] == 'api' %} is-selected{% endif %}">
       API
-      <sup class="spectrum-Body--small"><i>(alpha)</i><sup>
     </a>
     <a href="/resources" class="spectrum-Body2 guide-Header-link{% if url_parts[1] == 'resources' %} is-selected{% endif %}">
       Resources

--- a/api/guides/encrypting_values.md
+++ b/api/guides/encrypting_values.md
@@ -13,10 +13,6 @@ The Launch platform achieves this by utilizing GPG encryption and decryption.
 Using GPG, sensitive values may be encrypted in such a way that they are only
 decryptable by the Launch platform.
 
-{% alert info, Reminder %}
-The API is in an alpha state. As such, the Launch public GPG key, and
-the steps to obtain it outlined below, are subject to change.
-{% endalert %}
 
 ## Obtain the public GPG key
 

--- a/css/docs.css
+++ b/css/docs.css
@@ -501,6 +501,9 @@ pre.html {
   color: #ff8ce6;
 }
 
+pre {
+  word-wrap: break-word;
+}
 
 code,
 pre {
@@ -515,11 +518,6 @@ code {
 
 pre code {
   padding: 0
-}
-
-code,
-pre {
-  /* margin-top: 10px; */
 }
 
 code, code.prettyprint, pre.prettyprint {


### PR DESCRIPTION
#### Purpose

Remove alpha indicators. Cleanup.

#### Changes

- Remove alpha tag from API section header.
- Set bundler to use 4 jobs during install.
- Fix wrapping in code examples.