### PR TITLE
Require Ruby 2.6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby RUBY_VERSION
+ruby '~> 2.6.0'
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ DEPENDENCIES
   pry-byebug
 
 RUBY VERSION
-   ruby 2.6.1p33
+   ruby 2.6.3p62
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
#### Purpose
Enforce the README requirement of Ruby 2.6.x.

#### Details
When I did a `bundle install` with Ruby 2.5 active, the install succeeded,
and rewrote the "RUBY VERSION" section of `Gemfile.lock` to use my
active Ruby version (2.5).

With this `Gemfile` change, `bundle install` with Ruby 2.5 active causes an error,
as desired.

#### Changes
Changed the `Gemfile` ruby requirement from
```
ruby RUBY_VERSION
```
to
```
ruby "~> 2.6.0"
```