### PR TITLE
make label:unstable visible on Notes pages

### DIFF
--- a/api/reference/1.0/data_elements/list_notes.md
+++ b/api/reference/1.0/data_elements/list_notes.md
@@ -6,6 +6,8 @@ labels:
 
 # List Notes for a DataElement
 
+{% labels %}
+
 Retrieve the Notes attached to the specified DataElement.
 
 {% filters note %}

--- a/api/reference/1.0/extensions/list_notes.md
+++ b/api/reference/1.0/extensions/list_notes.md
@@ -6,6 +6,8 @@ labels:
 
 # List Notes for an Extension
 
+{% labels %}
+
 Retrieve the Notes attached to the specified Extension.
 
 {% filters note %}

--- a/api/reference/1.0/libraries/list_notes.md
+++ b/api/reference/1.0/libraries/list_notes.md
@@ -6,6 +6,8 @@ labels:
 
 # List Notes for a Library
 
+{% labels %}
+
 Retrieve the Notes attached to the specified Library.
 
 {% filters note %}

--- a/api/reference/1.0/notes/create/data_element.md
+++ b/api/reference/1.0/notes/create/data_element.md
@@ -6,6 +6,8 @@ labels:
 
 # Create a Note on a DataElement
 
+{% labels %}
+
 {% form note.create %}
 
 {% scenario data_element_notes.create %}

--- a/api/reference/1.0/notes/create/extension.md
+++ b/api/reference/1.0/notes/create/extension.md
@@ -6,6 +6,8 @@ labels:
 
 # Create a Note on an Extension
 
+{% labels %}
+
 {% form note.create %}
 
 {% scenario extension_notes.create %}

--- a/api/reference/1.0/notes/create/library.md
+++ b/api/reference/1.0/notes/create/library.md
@@ -6,6 +6,8 @@ labels:
 
 # Create a Note on a Library
 
+{% labels %}
+
 {% form note.create %}
 
 {% scenario library_notes.create %}

--- a/api/reference/1.0/notes/create/property.md
+++ b/api/reference/1.0/notes/create/property.md
@@ -6,6 +6,8 @@ labels:
 
 # Create a Note on a Property
 
+{% labels %}
+
 {% form note.create %}
 
 {% scenario property_notes.create %}

--- a/api/reference/1.0/notes/create/rule.md
+++ b/api/reference/1.0/notes/create/rule.md
@@ -6,6 +6,8 @@ labels:
 
 # Create a Note on a Rule
 
+{% labels %}
+
 {% form note.create %}
 
 {% scenario rule_notes.create %}

--- a/api/reference/1.0/notes/create/rule_component.md
+++ b/api/reference/1.0/notes/create/rule_component.md
@@ -6,6 +6,8 @@ labels:
 
 # Create a Note on a RuleComponent
 
+{% labels %}
+
 {% form note.create %}
 
 {% scenario rule_component_notes.create %}

--- a/api/reference/1.0/notes/fetch.md
+++ b/api/reference/1.0/notes/fetch.md
@@ -6,6 +6,8 @@ labels:
 
 # Fetch a Note
 
+{% labels %}
+
 Retrieve a specific Note, based on its ID.
 
 {% scenario notes.show %}

--- a/api/reference/1.0/notes/index.md
+++ b/api/reference/1.0/notes/index.md
@@ -6,6 +6,8 @@ labels:
 
 # Notes
 
+{% labels %}
+
 `Notes` are textual annotations you can add to Launch resources of these types:
 - `DataElements`
 - `Extensions`

--- a/api/reference/1.0/properties/list_notes.md
+++ b/api/reference/1.0/properties/list_notes.md
@@ -6,6 +6,8 @@ labels:
 
 # List Notes for a Property
 
+{% labels %}
+
 Retrieve the Notes attached to the specified Property.
 
 {% filters note %}

--- a/api/reference/1.0/rule_components/list_notes.md
+++ b/api/reference/1.0/rule_components/list_notes.md
@@ -6,6 +6,8 @@ labels:
 
 # List Notes for a RuleComponent
 
+{% labels %}
+
 Retrieve the Notes attached to the specified RuleComponent.
 
 {% filters note %}

--- a/api/reference/1.0/rules/list_notes.md
+++ b/api/reference/1.0/rules/list_notes.md
@@ -6,6 +6,8 @@ labels:
 
 # List Notes for a Rule
 
+{% labels %}
+
 Retrieve the Notes attached to the specified Rule.
 
 {% filters note %}

--- a/api/reference/1.0/rules/list_rule_component_notes.md
+++ b/api/reference/1.0/rules/list_rule_component_notes.md
@@ -6,6 +6,8 @@ labels:
 
 # List Notes for RuleComponents of a Rule
 
+{% labels %}
+
 Retrieve the Notes attached to the various RuleComponents of the specified
 Rule. Notes attached directly to the Rule itself are _not_ included.
 


### PR DESCRIPTION
#### Purpose
Add the `{% labels %}` macro in page bodies, so users can _see_ that the documentation is for an unstable API.
