### PR TITLE
Update Create Extension Doc To Synchronous Request

### DIFF
--- a/api/reference/1.0/extensions/create.md
+++ b/api/reference/1.0/extensions/create.md
@@ -4,8 +4,7 @@ title: Create
 
 # Create an Extension
 
-Add an Extension to a Property. Installation is **not** an
-asynchronous action. After performing a request to add an Extension to a
+Add an Extension to a Property. After performing a request to add an Extension to a
 Property, When the installation task has
 completed, the Extension response will be returned based on the success or
 failure of the task.

--- a/api/reference/1.0/extensions/create.md
+++ b/api/reference/1.0/extensions/create.md
@@ -4,38 +4,26 @@ title: Create
 
 # Create an Extension
 
-Add an Extension to a Property. Installation is an
+Add an Extension to a Property. Installation is **not** an
 asynchronous action. After performing a request to add an Extension to a
-Property, an Extension response will be returned with an
-`installation_status` of `pending`. When the installation task has
-completed, the Extension will be updated based on the success or
+Property, When the installation task has
+completed, the Extension response will be returned based on the success or
 failure of the task.
 
-Extensions are processed asynchronously and have an `installation_status`
-attribute representing the current status of the Extension installation.
-There are three possible `installation_status` values:
-
-#### `pending`
-
-When an Extension is created, `installation_status` is set to `pending`.
-This indicates that DTM received the request to make the ExtensionPackage
-available as Extension to the specified Property, and will begin the
-installation process.
-
-Extensions with an `installation_status` of `pending` are not available
-for use.
+Extensions are processed synchronously and return an `installation_status`
+attribute representing the final status of the Extension installation.
+There are two possible `installation_status` values:
 
 #### `succeeded`
 
 When processing of the installation request for the Extension has completed,
-if the installation was successful, the `installation_status` will change
-to `succeeded`.
+if the installation was successful, the `installation_status` will be `succeeded`.
 
 #### `failed`
 
 When processing of the installation request for the Extension has completed,
 if the installation was not successful, the `installation_status` will
-change to `failed`.
+be `failed`.
 
 Extensions with an `installation_status` of `failed` are not available
 for use.


### PR DESCRIPTION
#### Purpose
As per my conversation with @thebenrob , the documentation is outdated and falsely presents a "synchronous" request as "asynchronous". This has implications where developers are mislead.


#### Changes
As a solution to the same, I've updated the instructions to accurately present the type of the request as well as updated instructions to depict the response of a `sync` request instead of returning a `pending` status (characteristics of a `async` request.)

#### Caveats
The proposed changes may need to altered if the API response is not just two types but multiple which is very unlikely IMO.

#### Additional helpful information
None.

