### PR TITLE
Added host and port switches to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ bundle install
 Next, start Jekyll.
 
 ```bash
-bundle exec jekyll serve --host localhost --port 4000
+bundle exec jekyll serve --port 4000
 ```
 
 #### Preview

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ bundle install
 Next, start Jekyll.
 
 ```bash
-bundle exec jekyll serve
+bundle exec jekyll serve --host localhost --port 4000
 ```
 
 #### Preview


### PR DESCRIPTION
#### Purpose
When the host and port switches weren't mentioned explicitlty, the server ran into some error with the default port. So for such cases, they can change the port easily now with this README.md explicitly mentioning the host and port switches without having to google how to.

#### Changes
Added explicit host and port switches while it ran on default host and port (localhost , 4000) previously



