### PR TITLE
Document search value_operator

### DIFF
--- a/api/guides/searching.md
+++ b/api/guides/searching.md
@@ -77,6 +77,7 @@ An example request with all available options:
       - `lt` - Integer - Less than the supplied value, non-inclusive.
       - `lte` - Integer - Less than or equal to the supplied value.
     - `value` - String - The value to use for the search query.
+    - `value_operator` - String - Boolean logic used to interpret terms in the query `value`. Allowed values: `AND`, `OR`. Default value: `AND`. May only be used in-conjuntion with `value` queries.
 - `sort` - Array, Object - Order in which to sort results.
   - document field path - String - Path: allowed characters: `a-z` and `.` . Values: `desc`, `asc`
 - `resource_types` - Array, String - The resource types to search.
@@ -173,7 +174,11 @@ Search is concerned with answering how relevant a document is to a supplied quer
 - `type` - Exact match, case-sensitive
 
 
-Search query values are split into terms for matching against indexed documents. Terms are `OR`'d. The more terms that match, the higher the `match_score`. Due to the nature of term matching, it's very possible nothing closely matches the desired value and to obtain a result set where the value matched on a very basic level, i.e. a few characters of text matched.
+Search query values are split into terms for matching against indexed documents. Terms are `AND`'ed by default.
+
+When using `AND` as the `value_operator`, a query value of `My Rule Holiday Sale` is interpereted as documents with a field containing `My AND Rule AND Holiday AND Sale`.
+
+When using `OR` as the `value_operator`, a query value of `My Rule Holiday Sale` is interpereted as documents with a field containing `My OR Rule OR Holiday OR Sale`. The more terms that match, the higher the `match_score`. Due to the nature of partial term matching, it's very possible nothing closely matches the desired value, and to obtain a result set where the value matched on a very basic level, i.e. a few characters of text matched.
 
 
 ## Common search examples
@@ -306,6 +311,29 @@ curl -X POST "https://reactor.adobe.io/search" \
     "query": {
       "id": {
         "value": "PR3cab070a9eb3423894e4a3038ef0e7b7"
+      }
+    }
+  }
+}
+'
+```
+
+#### Perform a search using "OR" term logic
+
+```bash
+curl -X POST "https://reactor.adobe.io/search" \
+  -H "Accept: application/vnd.api+json;revision=1" \
+  -H "Content-Type: application/vnd.api+json" \
+  -H "Authorization: Bearer [TOKEN]" \
+  -H "X-Api-Key: [KEY]" \
+  -H "X-Gw-Ims-Org-Id: [ORG_ID]" \
+  -d '
+{
+  "data" : {
+    "query": {
+      "attributes.display_name": {
+        "value": "My Rule Holiday Sale",
+        "value_operator: "OR"
       }
     }
   }

--- a/api/reference/1.0/search/perform.md
+++ b/api/reference/1.0/search/perform.md
@@ -145,6 +145,19 @@ labels:
               </td>
             </tr>
             <tr class="spectrum-Table-row">
+              <td class="spectrum-Table-cell" style="padding-left:80px"><code>value_operator</code></td>
+              <td class="spectrum-Table-cell">String</td>
+              <td class="spectrum-Table-cell"></td>
+              <td class="spectrum-Table-cell">
+                <ul style="margin: 0px; padding-left: 20px">
+                  <li>Boolean logic used to interpret terms in the query <code>value</code>.</li>
+                  <li>Allowed values: <code>AND</code>, <code>OR</code>.</li>
+                  <li>Default value: <code>AND</code>.</li>
+                  <li>May only be used in-conjuntion with <code>value</code> queries.</li>
+                </ul>
+              </td>
+            </tr>
+            <tr class="spectrum-Table-row">
               <td class="spectrum-Table-cell"><code>sort</code></td>
               <td class="spectrum-Table-cell">Array, Object</td>
               <td class="spectrum-Table-cell">Optional</td>

--- a/api/release_notes/2019-release-notes.md
+++ b/api/release_notes/2019-release-notes.md
@@ -4,6 +4,16 @@ title: 2019 Release Notes
 
 # 2019 Reactor Release Notes
 
+## 2019-12-03
+
+<hr class="spectrum-Rule spectrum-Rule--medium">
+
+### Search
+
+Search now supports `value_operator` (`AND`/`OR`) for `value` queries. `value` queries now default to an `AND` operator.
+
+<br>
+
 ## 2019-11-20
 
 <hr class="spectrum-Rule spectrum-Rule--medium">


### PR DESCRIPTION
#### Purpose

Update documentation reflect the addition of `value_operator` for search.

#### Changes

- Refresh API spec
- Document `value_operator`