### PR TITLE
Update documentation for Rule and Rule Component

### DIFF
--- a/api/reference/1.0/rule_components/create.md
+++ b/api/reference/1.0/rule_components/create.md
@@ -4,6 +4,10 @@ title: Create
 
 # Create a RuleComponent
 
+{% alert info, Note %}
+Creating a `RuleComponent` will also update the parent Rule's `updated_at` timestamp.
+{% endalert %}
+
 {% form rule_component.post %}
 
 {% scenario rule_components.create %}

--- a/api/reference/1.0/rule_components/update.md
+++ b/api/reference/1.0/rule_components/update.md
@@ -4,6 +4,10 @@ title: Update
 
 # Update a RuleComponent
 
+{% alert info, Note %}
+Updating a `RuleComponent` will also update the parent Rule's `updated_at` timestamp.
+{% endalert %}
+
 {% form rule_component.patch %}
 
 {% scenario rule_components.update %}

--- a/api/reference/1.0/rules/fetch.md
+++ b/api/reference/1.0/rules/fetch.md
@@ -12,4 +12,8 @@ Therefore, it is possible to retrieve a deleted `Rule`.
 Deleted `Rules` can be identified by the presence of `data.meta.deleted_at`.
 {% endalert %}
 
+{% alert info, Note %}
+A Rule's `updated_at` timestamp will also reflect changes to it's child `RuleComponents`.
+{% endalert %}
+
 {% scenario rules.show %}


### PR DESCRIPTION

#### Purpose
Update `Rule` and `RuleComponent` documentation

#### Changes
- The Reactor Team is deploying a change to the behavior of the  `Rule` and `RuleComponent` objects.
- If a new `RuleComponent` is created, its parent `Rule`'s `updated_at` timestamp will be updated.
- If a `RuleComponent` is updated, its parent `Rule`'s `updated_at` timestamp will be updated..

#### Caveats
N/A

#### Additional helpful information
N/A

