### PR TITLE
adding-guides-paging

### DIFF
--- a/api/guides/paging.md
+++ b/api/guides/paging.md
@@ -1,0 +1,28 @@
+---
+title: Paging
+---
+
+# Paging
+
+APIs results are paged. The default page size is 25 elements. Details about the pagination are reported in the meta.pagination section of the API response.
+
+`"meta": {"pagination": {"current_page": 1, "next_page": 2, "prev_page": null,  "total_pages": 4, "total_count": 90}}`
+
+It is possible to get a specific page and to modify the size of a page.
+
+## Get a specific page
+
+To get a specific page.
+
+`GET /properties/:property_id/data_elements?page[number]=<page number>`
+
+## Change the page size
+
+To change the page size.
+
+`GET /properties/:property_id/data_elements?page[size]=<page size>`
+
+The options can be combined together.
+
+`GET /properties/:property_id/data_elements?page[size]=<page size>&page[number]=<page number>`
+


### PR DESCRIPTION
#### Purpose

Providing details about page[number] and page[size] parameters for the list and fetche APIs.

#### Changes

Adding `Paging` page in the Guide section.

#### Caveats


#### Additional helpful information


