### PR TITLE
Removed version requirement

### DIFF
--- a/extensions/guides/quickstart.md
+++ b/extensions/guides/quickstart.md
@@ -8,13 +8,7 @@ To get you up and running and building extensions, we will be using the open-sou
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/en/download/)
-
-Node.js comes bundled with npm. The version of npm you must have installed is 5.2.0 or greater. You can determine the version of npm you have installed by running the following command from the command line:
-
-```
-npm -v
-```
+- Install [Node.js](https://nodejs.org/en/download/).
 
 ### Extension Setup
 


### PR DESCRIPTION
#### Purpose
Rather than listing the minimum version of npm in the documentation, each tool will now indicate the minimum node version required in the [`engines`](https://docs.npmjs.com/files/package.json#engines) field within package.json. When the developer tries to run the tool with a node version that is too old, they'll receive an error in the console that will tell them which version is needed. That should be sufficient.

#### Changes
Removed minimum npm version info.

#### Caveats


#### Additional helpful information


