### PR TITLE
Clarifying who can gain access to an IMS access token.

### DIFF
--- a/extensions/reference/views.md
+++ b/extensions/reference/views.md
@@ -73,7 +73,7 @@ The `init` method will be called by Launch as soon as the view has been loaded i
 
   * `info.tokens.imsAccess: string`
 
-    For accessing Adobe APIs from inside the view you will need to usually use an IMS token. This token will made available only for extensions developed by Adobe. If you are an Adobe employee building an Adobe extension, please [email the Launch engineering team](mailto:reactor@adobe.com) and provide the name of the extension so we can add it to the allowed list.
+    For accessing Adobe APIs from inside the view you will need to usually use an IMS token. This token will made available only for extensions developed by Adobe. If you are an Adobe employee representing an extension authored by Adobe, please [email the Launch engineering team](mailto:reactor@adobe.com) and provide the name of the extension so we can add it to the allowed list.
 
 * `info.company: Object`
 

--- a/extensions/reference/views.md
+++ b/extensions/reference/views.md
@@ -73,7 +73,7 @@ The `init` method will be called by Launch as soon as the view has been loaded i
 
   * `info.tokens.imsAccess: string`
 
-    For accessing Adobe APIs from inside the view you will need to usually use an IMS token. This token will made available only for extensions developed by Adobe. If you are building an Adobe extension, please [email the Launch engineering team](mailto:reactor@adobe.com) and provide the name of the extension so we can add it to the allowed list.
+    For accessing Adobe APIs from inside the view you will need to usually use an IMS token. This token will made available only for extensions developed by Adobe. If you are an Adobe employee building an Adobe extension, please [email the Launch engineering team](mailto:reactor@adobe.com) and provide the name of the extension so we can add it to the allowed list.
 
 * `info.company: Object`
 


### PR DESCRIPTION
#### Purpose
There was some confusion around whether third-party developers could build extensions that can access `info.tokens.imsAccess`. My goal is to make it a little more clear.

#### Changes
Specified that Adobe employees can request that their extension be added to the allowed list.

#### Caveats


#### Additional helpful information


