### PR TITLE
Add ability to order sections

### DIFF
--- a/_plugins/docs.rb
+++ b/_plugins/docs.rb
@@ -36,6 +36,12 @@ def directory_hash(site, path, name=nil)
       documents << page if page
     end
   end
+
+  order_directive = site.config.dig('section_orders', path) || []
+  data['children'].sort_by! do |child|
+    [order_directive&.index(child['name']) || 50, child['name']]
+  end
+
   data['documents'].sort_by! do |doc|
     is_overview = doc.data['title'] == 'Overview' ? -1 : 0
     order_attr = doc.data['order'] || -1


### PR DESCRIPTION
#### Purpose

A quick and low-effort way to allow the ability to order children in sections.

#### Additional helpful information

Configure via the `section_orders ` option in `_config.yml`. E.g.:

```yaml
section_orders:
  extensions:
    - submissions
    - guides
```

Children not specified in the list fall back to ordering by name.
