### PR TITLE
Remove filters from API AuditEvent list section

### DIFF
--- a/api/reference/1.0/audit_events/list.md
+++ b/api/reference/1.0/audit_events/list.md
@@ -10,6 +10,4 @@ labels:
 
 Retrieve the AuditEvents for all the Properties owned by your active organization.
 
-{% filters audit_event %}
-
 {% scenario audit_events.index %}


### PR DESCRIPTION
#### Purpose

Remove filters from API AuditEvent list section. This endpoint does not currently support filters.


